### PR TITLE
Adding check for undefined raws in "safeCopyDeclarations" func

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,7 +323,7 @@ module.exports = postcss.plugin('postcss-extend', function extend() {
         // /*DEBUG*/appendout('./test/debugout.txt', '\nnodeDest Nodes:\n' + nodeDest.nodes);
         var clone = node.clone();
         //For lack of a better way to analyse how much tabbing is required:
-        if (node.raws.before){
+        if (node.raws.before) {
           clone.raws.before = nodeOrigin.parent === nodeDest.parent ? node.raws.before : node.raws.before + '\t';
         }
         if (node.raws.after) clone.raws.after = node.raws.after;

--- a/index.js
+++ b/index.js
@@ -323,13 +323,11 @@ module.exports = postcss.plugin('postcss-extend', function extend() {
         // /*DEBUG*/appendout('./test/debugout.txt', '\nnodeDest Nodes:\n' + nodeDest.nodes);
         var clone = node.clone();
         //For lack of a better way to analyse how much tabbing is required:
-        if (nodeOrigin.parent === nodeDest.parent) {
-          clone.raws.before = node.raws.before;
-        } else {
-          clone.raws.before = node.raws.before + '\t';
+        if (node.raws.before){
+          clone.raws.before = nodeOrigin.parent === nodeDest.parent ? node.raws.before : node.raws.before + '\t';
         }
-        clone.raws.after = node.raws.after;
-        clone.raws.between = node.raws.between;
+        if (node.raws.after) clone.raws.after = node.raws.after;
+        if (node.raws.between) clone.raws.between = node.raws.between;
         nodeDest.append(clone);
       });
     }


### PR DESCRIPTION
I was getting this weird error while extending from within a @media declaration. Using the readme example, I put in this:  

```css
.potato {
  color: white;
  outline: brown;
  font-family: sans-serif;
}
@media (width > 600px) {
  .potato:first {
    float: center;
  }
  .spud {
    @extend .potato;
    color: red;
    font-size: 4em;
  }
}
```

which was being output as: 

```css
.potato{
    color: white;
    outline: brown;
    font-family: sans-serif;
}
@media (width > 600px){
    .potato:first, .spud:first{
        float: center;
    }
    .spud{
        color: red;
        font-size: 4em;undefined	outline: brown;undefined	font-family: sans-serif;
    }
}
```

I'm not sure whether one of my upstream plugins is messing with my declaration raws (probably is the case), but the issue for me was an empty node.raws, so the cloned node's "before," "after," and "between" raw props were all getting instantiated as "undefined" in the "safeCopyDeclarations" function. This fix just checks to make sure node.raws has each property before assigning them to the cloned node. 

Let me know if this looks alright; thanks!